### PR TITLE
merge tmedwards/sugarcube-2 to pompom454/tea

### DIFF
--- a/docs/api/api-config.md
+++ b/docs/api/api-config.md
@@ -243,6 +243,35 @@ Config.history.controls = false;
 
 <!-- *********************************************************************** -->
 
+### `Config.history.disableDeltas` ↔ `boolean` (default: `false`) {#config-api-property-history-disabledeltas}
+
+Determines whether the history states are delta encoded/decoded.
+
+<p role="note" class="tip"><b>Tip:</b>
+For the <em>vast majority</em> of projects it is <strong><em>strongly recommended</em></strong> to leave this setting at the default value of <code>false</code>.
+</p>
+
+<p role="note" class="warning"><b>Warning:</b>
+Changing this setting's value will invalidate all saves and sessions generated while the opposite value was in effect.
+</p>
+
+#### History:
+
+* `v2.38.0`: Introduced.
+
+#### Value:
+
+A `boolean` value signifying whether delta encoding/decoding of the history states is disabled.
+
+#### Examples:
+
+```javascript
+// Disables delta encoding/decoding of the history.
+Config.history.disableDeltas = true;
+```
+
+<!-- *********************************************************************** -->
+
 ### `Config.history.maxStates` ↔ *integer* `number` (default: `40`) {#config-api-property-history-maxstates}
 
 Sets the maximum number of states (moments) to which the history is allowed to grow.  Should the history exceed the limit, states will be dropped from the past (oldest first).

--- a/docs/table-of-contents.md
+++ b/docs/table-of-contents.md
@@ -295,6 +295,7 @@
 	* [`Config.audio.preloadMetadata`](#config-api-property-audio-preloadmetadata)
 * [History Settings](#config-api-history)
 	* [`Config.history.controls`](#config-api-property-history-controls)
+	* [`Config.history.disableDeltas`](#config-api-property-history-disabledeltas)
 	* [`Config.history.maxStates`](#config-api-property-history-maxstates)
 * [Macros Settings](#config-api-macros)
 	* [`Config.macros.maxLoopIterations`](#config-api-property-macros-maxloopiterations)

--- a/src/config.js
+++ b/src/config.js
@@ -21,8 +21,9 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 	let cfgAudioPreloadMetadata   = true;
 
 	// State history settings.
-	let cfgHistoryControls  = true;
-	let cfgHistoryMaxStates = 40;
+	let cfgHistoryControls      = true;
+	let cfgHistoryDisableDeltas = false;
+	let cfgHistoryMaxStates     = 40;
 
 	// Macros settings.
 	let cfgMacrosMaxLoopIterations   = 1000;
@@ -111,6 +112,9 @@ var Config = (() => { // eslint-disable-line no-unused-vars, no-var
 
 				cfgHistoryControls = controls;
 			},
+
+			get disableDeltas() { return cfgHistoryDisableDeltas; },
+			set disableDeltas(value) { cfgHistoryDisableDeltas = Boolean(value); },
 
 			get maxStates() { return cfgHistoryMaxStates; },
 			set maxStates(value) {

--- a/src/save.js
+++ b/src/save.js
@@ -931,9 +931,11 @@ var Save = (() => { // eslint-disable-line no-unused-vars, no-var
 			/* [/DEPRECATED] */
 		));
 
-		// Delta encode the state history and delete the non-encoded property.
-		save.state.delta = State.deltaEncode(save.state.history);
-		delete save.state.history;
+		if (!Config.history.disableDeltas) {
+			// Delta encode the state history and delete the non-encoded property.
+			save.state.delta = State.deltaEncode(save.state.history);
+			delete save.state.history;
+		}
 
 		return save;
 	}
@@ -952,7 +954,7 @@ var Save = (() => { // eslint-disable-line no-unused-vars, no-var
 			|| !Object.hasOwn(save, 'id')
 			|| !Object.hasOwn(save, 'state')
 			|| typeof save.state !== 'object'
-			|| !Object.hasOwn(save.state, 'delta')
+			|| !Object.hasOwn(save.state, Config.history.disableDeltas ? 'history' : 'delta')
 		) {
 			throw new Error(L10n.get('saveErrorInvalidData'));
 		}
@@ -961,11 +963,13 @@ var Save = (() => { // eslint-disable-line no-unused-vars, no-var
 			throw new Error(L10n.get('saveErrorIdMismatch'));
 		}
 
-		// Delta decode the state history and delete the encoded property.
-		/* eslint-disable no-param-reassign */
-		save.state.history = State.deltaDecode(save.state.delta);
-		delete save.state.delta;
-		/* eslint-enable no-param-reassign */
+		if (!Config.history.disableDeltas) {
+			// Delta decode the state history and delete the encoded property.
+			/* eslint-disable no-param-reassign */
+			save.state.history = State.deltaDecode(save.state.delta);
+			delete save.state.delta;
+			/* eslint-enable no-param-reassign */
+		}
 
 		/* [DEPRECATED] */
 		// TODO: Delete this on January 2026.


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable option to disable delta encoding of history state and wire it through save/state handling and configuration.

New Features:
- Introduce Config.history.disableDeltas to control whether history states use delta encoding or store full history instead.

Enhancements:
- Update save serialization and deserialization logic to respect the disableDeltas option when encoding/decoding history.
- Adjust state marshaling/unmarshaling to support both delta-encoded and full-history representations based on configuration.

Documentation:
- Document the new Config.history.disableDeltas setting and add it to the API table of contents.